### PR TITLE
Use commit SHA pinning for action metadata files

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ runs:
           echo $(cygpath -w "${{ steps.set-path.outputs.path }}") >> $GITHUB_PATH
         fi
     -
-      uses: k1LoW/gh-setup@v1
+      uses: k1LoW/gh-setup@a2e69b734fd97adf7075e37b0f49b5dc5e1f44fc # v1.11.2
       with:
         repo: github.com/k1LoW/tbls
         github-token: ${{ inputs.github-token }}


### PR DESCRIPTION
We're trying to enable GitHub's recent ["enforce SHA pinning" configuration](https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/#enforce-sha-pinning).  
This feature requires all GitHub Action calls—including dependent third-party actions—to be written in the SHA-pinned style.  
Therefore, we are motivated to ensure that every third-party action we depend on is properly version-pinned.

If there are no objections, I’d like to update the unpinned action calls in the action metadata file to use SHA pinning.  
This format is compatible with version updates via Renovate or Dependabot, and can also be updated locally with tools like [pinact](https://github.com/suzuki-shunsuke/pinact).